### PR TITLE
[WIP] Feature: Python script and module to check dataset readiness for data preservation

### DIFF
--- a/ldcoolp/preserve/__init__.py
+++ b/ldcoolp/preserve/__init__.py
@@ -1,0 +1,1 @@
+from .main import Preserve

--- a/ldcoolp/preserve/main.py
+++ b/ldcoolp/preserve/main.py
@@ -186,15 +186,7 @@ class Preserve:
             self.log.info("No old README.txt files found!")
         else:
             self.log.info(f"Old README.txt files found, N={len(files_find_list)}!")
-            for o_path in files_find_list:
-                self.log.info(o_path.relative_to(self.version_dir))
-            self.log.info("PROMPT: Do you you wish to delete all of these files")
-            src_input = input("PROMPT: Type 'yes'. Anything else will skip : ")
-            self.log.info(f"RESPONSE: {src_input}")
-            if src_input.lower() == 'yes':
-                for o_path in files_find_list:
-                    self.log.info(f"Removing: {o_path.relative_to(self.version_dir)}")
-                    o_path.unlink()
+            self.delete_files(files_find_list)
 
     def delete_hidden_files(self):
         """Find and remove all hidden files. See ``HIDDEN_FILES`` wildcards"""
@@ -208,14 +200,17 @@ class Preserve:
             self.log.info("No hidden files found!")
         else:
             self.log.info(f"Hidden files found, N={len(hidden_files_list)}!")
-            for h_path in hidden_files_list:
-                self.log.info(h_path.relative_to(self.version_dir))
-            self.log.info("PROMPT: Do you you wish to delete all of these files")
-            src_input = input("PROMPT: Type 'yes'. Anything else will skip : ")
-            self.log.info(f"RESPONSE: {src_input}")
-            if src_input.lower() == 'yes':
-                for h_path in hidden_files_list:
-                    self.log.info(f"Removing: {h_path.relative_to(self.version_dir)}")
-                    h_path.unlink()
+            self.delete_files(hidden_files_list)
 
         return hidden_files_list
+
+    def delete_files(self, files_list: List[Path]):
+        for f_path in files_list:
+            self.log.info(f_path.relative_to(self.version_dir))
+        self.log.info("PROMPT: Do you you wish to delete all of these files")
+        src_input = input("PROMPT: Type 'yes'. Anything else will skip : ")
+        self.log.info(f"RESPONSE: {src_input}")
+        if src_input.lower() == 'yes':
+            for f_path in files_list:
+                self.log.info(f"Removing: {f_path.relative_to(self.version_dir)}")
+                f_path.unlink()

--- a/ldcoolp/preserve/main.py
+++ b/ldcoolp/preserve/main.py
@@ -147,3 +147,21 @@ class Preserve:
 
             df = pd.DataFrame.from_dict(summary_list, orient='columns')
             return df
+
+    def make_symbolic_links(self, df):
+        """Construct symbolic links in DATA from ORIGINAL_DATA as needed
+
+        :param df: pandas DataFrame from ``check_files()``
+        """
+
+        # Get list of those in ORIGINAL_DATA
+        df_symlink = df.loc[df['data_location'] == self.original_data_path]
+
+        if df_symlink.empty:
+            self.log.info(f"All files are in {self.data_path}")
+            self.log.info("No symbolic links are needed! :-)")
+        else:
+            for index, row in df_symlink.iterrows():
+                self.log.info(f"{index}. Creating symbolic link for {row['name']}")
+                data_path = self.version_dir / self.data_path / row['name']
+                data_path.symlink_to(f"../{self.original_data_path}/{row['name']}")

--- a/ldcoolp/preserve/main.py
+++ b/ldcoolp/preserve/main.py
@@ -75,6 +75,13 @@ class Preserve:
             self.log.warning("Exiting !!!")
             raise OSError
 
+        # Ensure that METADATA folder exists (support for very old deposits)
+        m_path = self.version_dir / self.metadata_path
+        if not m_path.exists():
+            self.log.info(f"{self.metadata_path} NOT found!")
+            self.log.info(f"Creating: {self.metadata_path}")
+            m_path.mkdir()
+
         # Retrieve Figshare metadata and save metadata
         self.article_metadata = self.get_metadata()
 

--- a/ldcoolp/preserve/main.py
+++ b/ldcoolp/preserve/main.py
@@ -13,6 +13,9 @@ from ..config import config_default_dict
 from ..curation import metadata
 from ..curation.inspection import checksum
 
+# Wildcards for globbing hidden files
+HIDDEN_FILES = ['*DS_Store', '.*.docx', '.*.pdf']
+
 
 class Preserve:
     """
@@ -165,3 +168,27 @@ class Preserve:
                 self.log.info(f"{index}. Creating symbolic link for {row['name']}")
                 data_path = self.version_dir / self.data_path / row['name']
                 data_path.symlink_to(f"../{self.original_data_path}/{row['name']}")
+
+    def delete_hidden_files(self):
+        """Find and remove all hidden files. See ``HIDDEN_FILES`` wildcards"""
+        hidden_files_list = []
+        for hidden in HIDDEN_FILES:
+            file_find = list(self.version_dir.rglob(hidden))
+            if len(file_find) > 0:
+                hidden_files_list.extend(file_find)
+
+        if len(hidden_files_list) == 0:
+            self.log.info("No hidden files found!")
+        else:
+            self.log.info(f"Hidden files found, N={len(hidden_files_list)}!")
+            for h_path in hidden_files_list:
+                self.log.info(h_path.relative_to(self.version_dir))
+            self.log.info("PROMPT: Do you you wish to delete all of these files")
+            src_input = input("PROMPT: Type 'yes'. Anything else will skip : ")
+            self.log.info(f"RESPONSE: {src_input}")
+            if src_input.lower() == 'yes':
+                for h_path in hidden_files_list:
+                    self.log.info(f"Removing: {h_path.relative_to(self.version_dir)}")
+                    h_path.unlink()
+
+        return hidden_files_list

--- a/ldcoolp/preserve/main.py
+++ b/ldcoolp/preserve/main.py
@@ -71,7 +71,7 @@ class Preserve:
         if self.version_dir.exists():
             self.log.info("Article and version found!")
         else:
-            self.log.warning("Version not found.")
+            self.log.warning("Version not found!")
             self.log.warning("Exiting !!!")
             raise OSError
 
@@ -183,7 +183,7 @@ class Preserve:
         d_dir = self.version_dir / self.data_path
         files_find_list = list(d_dir.glob('README_????-??-??T*.txt'))
         if len(files_find_list) == 0:
-            self.log.info("No old README.txt files found!")
+            self.log.info("No old README.txt files found! :-)")
         else:
             self.log.info(f"Old README.txt files found, N={len(files_find_list)}!")
             self.delete_files(files_find_list)
@@ -197,7 +197,7 @@ class Preserve:
                 hidden_files_list.extend(file_find)
 
         if len(hidden_files_list) == 0:
-            self.log.info("No hidden files found!")
+            self.log.info("No hidden files found! :-)")
         else:
             self.log.info(f"Hidden files found, N={len(hidden_files_list)}!")
             self.delete_files(hidden_files_list)
@@ -214,3 +214,5 @@ class Preserve:
             for f_path in files_list:
                 self.log.info(f"Removing: {f_path.relative_to(self.version_dir)}")
                 f_path.unlink()
+        else:
+            self.log.info("Not deleting files.")

--- a/ldcoolp/preserve/main.py
+++ b/ldcoolp/preserve/main.py
@@ -177,6 +177,25 @@ class Preserve:
                 data_path = self.version_dir / self.data_path / row['name']
                 data_path.symlink_to(f"../{self.original_data_path}/{row['name']}")
 
+    def delete_old_readme_files(self):
+        """Find and remove all old README.txt files in DATA"""
+
+        d_dir = self.version_dir / self.data_path
+        files_find_list = list(d_dir.glob('README_????-??-??T*.txt'))
+        if len(files_find_list) == 0:
+            self.log.info("No old README.txt files found!")
+        else:
+            self.log.info(f"Old README.txt files found, N={len(files_find_list)}!")
+            for o_path in files_find_list:
+                self.log.info(o_path.relative_to(self.version_dir))
+            self.log.info("PROMPT: Do you you wish to delete all of these files")
+            src_input = input("PROMPT: Type 'yes'. Anything else will skip : ")
+            self.log.info(f"RESPONSE: {src_input}")
+            if src_input.lower() == 'yes':
+                for o_path in files_find_list:
+                    self.log.info(f"Removing: {o_path.relative_to(self.version_dir)}")
+                    o_path.unlink()
+
     def delete_hidden_files(self):
         """Find and remove all hidden files. See ``HIDDEN_FILES`` wildcards"""
         hidden_files_list = []

--- a/ldcoolp/preserve/main.py
+++ b/ldcoolp/preserve/main.py
@@ -205,6 +205,7 @@ class Preserve:
         return hidden_files_list
 
     def delete_files(self, files_list: List[Path]):
+        """Delete list of files if response to prompt is yes"""
         for f_path in files_list:
             self.log.info(f_path.relative_to(self.version_dir))
         self.log.info("PROMPT: Do you you wish to delete all of these files")

--- a/ldcoolp/preserve/main.py
+++ b/ldcoolp/preserve/main.py
@@ -57,9 +57,8 @@ class Preserve:
             raise ValueError
 
         self.folder_name = Path(list_paths[0])
-        print(self.folder_name)
-        v_dir = self.folder_name / f"v{self.version_no:02}"
-        if v_dir.exists():
+        self.version_dir = self.folder_name / f"v{self.version_no:02}"
+        if self.version_dir.exists():
             self.log.info("Article and version found!")
         else:
             self.log.warning("Version not found.")
@@ -74,3 +73,13 @@ class Preserve:
         article_metadata = self.fs.get_article_details(self.article_id,
                                                        self.version_no)
         return article_metadata
+
+    def save_metadata(self):
+        """Write JSON file containing Figshare metadata"""
+        out_file_prefix = f"published_{self.article_id}"
+        metadata.save_metadata(self.article_metadata,
+                               out_file_prefix,
+                               metadata_source='FIGSHARE',
+                               root_directory=self.version_dir,
+                               metadata_directory='METADATA',
+                               log=self.log)

--- a/ldcoolp/preserve/main.py
+++ b/ldcoolp/preserve/main.py
@@ -50,6 +50,7 @@ class Preserve:
         self.published_folder = self.curation_dict['folder_published']
         self.data_path = self.curation_dict['folder_copy_data']  # DATA
         self.original_data_path = self.curation_dict['folder_data']  # ORIGINAL_DATA
+        self.metadata_path = self.curation_dict['folder_metadata']  # METADATA
 
         # Search for path
         p_dir = Path(self.root_directory) / self.published_folder
@@ -90,7 +91,7 @@ class Preserve:
                                out_file_prefix,
                                metadata_source='FIGSHARE',
                                root_directory=self.version_dir,
-                               metadata_directory='METADATA',
+                               metadata_directory=self.metadata_path,
                                log=self.log)
 
     def check_files(self, save_files: bool = False) -> pd.DataFrame:
@@ -145,7 +146,7 @@ class Preserve:
                 metadata.save_metadata(summary_list, out_file_prefix,
                                        metadata_source='CHECKSUM',
                                        root_directory=self.version_dir,
-                                       metadata_directory='METADATA',
+                                       metadata_directory=self.metadata_path,
                                        save_csv=True, log=self.log)
 
             df = pd.DataFrame.from_dict(summary_list, orient='columns')

--- a/ldcoolp/preserve/main.py
+++ b/ldcoolp/preserve/main.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+
+from logging import Logger
+from redata.commons.logger import log_stdout
+
+# LD-Cool-P specific
+from figshare.figshare import Figshare
+from ..config import config_default_dict
+from ..curation import metadata
+from ..curation.inspection import checksum
+
+
+class Preserve:
+    """
+    Primary class for the preparation of curated datasets for data
+    preservation.
+
+    This ``class`` includes a number of built-in features such as
+    checking against the published metadata via MD5 checksum,
+    saving a JSON file containing the published metadata, deleting
+    hidden files, and changing curated folder to read-only
+
+    Attributes
+    ----------
+    article_id: Figshare article ID
+    version_no: Version number for article ID. Default: v1
+    """
+
+    def __init__(self, article_id: int, version_no: int = 1,
+                 config_dict: dict = config_default_dict,
+                 log: Logger = log_stdout()):
+
+        self.log = log
+        self.article_id = article_id
+        self.version_no = version_no
+
+        self.fs = Figshare()  # No token needed for public dataset
+
+        self.curation_dict = config_dict['curation']
+
+        self.root_directory = \
+            self.curation_dict[self.curation_dict['parent_dir']]
+        self.published_folder = self.curation_dict['folder_published']
+
+        # Search for path
+        p_dir = Path(self.root_directory) / self.published_folder
+        list_paths = list(p_dir.glob(f'*{self.article_id}'))
+        if len(list_paths) == 0:
+            self.log.warning(
+                f"No curated dataset found in {self.published_folder}.")
+            self.log.warning("Exiting !!!")
+            raise ValueError
+        if len(list_paths) > 1:
+            self.log.warning(
+                f"More than one paths found in {self.published_folder}.")
+            self.log.warning("Exiting !!!")
+            raise ValueError
+
+        self.folder_name = Path(list_paths[0])
+        print(self.folder_name)
+        v_dir = self.folder_name / f"v{self.version_no:02}"
+        if v_dir.exists():
+            self.log.info("Article and version found!")
+        else:
+            self.log.warning("Version not found.")
+            self.log.warning("Exiting !!!")
+            raise OSError
+
+        # Retrieve Figshare metadata and save metadata
+        self.article_metadata = self.get_metadata()
+
+    def get_metadata(self) -> dict:
+        """Retrieve Figshare metadata from public API"""
+        article_metadata = self.fs.get_article_details(self.article_id,
+                                                       self.version_no)
+        return article_metadata

--- a/ldcoolp/preserve/main.py
+++ b/ldcoolp/preserve/main.py
@@ -130,6 +130,7 @@ class Preserve:
                                        log=log_stdout())
 
                 summary_dict[n] = {
+                    'name': filename,
                     'data_location': data_location,
                     'checksum_status': checksum_flag,
                 }

--- a/ldcoolp/preserve/main.py
+++ b/ldcoolp/preserve/main.py
@@ -98,6 +98,7 @@ class Preserve:
                 f"Embargoed files! File checking is not possible at this time")
             self.log.warning(
                 f"Embargo date: {self.article_metadata['embargo_date']}")
+            raise SystemExit("NOTE: Embargoed datasets NOT supported at this point")
         else:
             summary_list = []  # Initialize
             files_list: List[Dict] = self.article_metadata['files']

--- a/ldcoolp/scripts/preserve_checks
+++ b/ldcoolp/scripts/preserve_checks
@@ -92,6 +92,13 @@ if __name__ == '__main__':
     # Step 1: Save Figshare metadata
     p.save_metadata()
 
+    # Step 2: Perform checksum verification on files
+    checksum_df = p.check_files()
+
+    for handler in log.handlers:
+        log_file = logger.get_log_file(handler)
+    logger.pandas_write_buffer(checksum_df, log_file)
+
     log.info(f"Completed: {args.article_id} ...")
 
     # Change permission to mode=666 (rw for all)

--- a/ldcoolp/scripts/preserve_checks
+++ b/ldcoolp/scripts/preserve_checks
@@ -105,6 +105,9 @@ if __name__ == '__main__':
             log_file = logger.get_log_file(handler)
         logger.pandas_write_buffer(checksum_df, log_file)
 
+        # Step 3: Resolve any checksum differences
+        checksum_df = p.update_files(checksum_df)
+
         # Step 4: Create symbolic links
         p.make_symbolic_links(checksum_df)
 

--- a/ldcoolp/scripts/preserve_checks
+++ b/ldcoolp/scripts/preserve_checks
@@ -97,13 +97,16 @@ if __name__ == '__main__':
     # Step 1: Save Figshare metadata
     p.save_metadata()
 
-    # Step 2: Perform checksum verification on files
     if not args.metadata_only:
+        # Step 2: Perform checksum verification on files
         checksum_df = p.check_files(save_files=True)
 
         for handler in log.handlers:
             log_file = logger.get_log_file(handler)
         logger.pandas_write_buffer(checksum_df, log_file)
+
+        # Step 4: Create symbolic links
+        p.make_symbolic_links(checksum_df)
 
     log.info(f"Completed: {args.article_id} ...")
 

--- a/ldcoolp/scripts/preserve_checks
+++ b/ldcoolp/scripts/preserve_checks
@@ -88,8 +88,11 @@ if __name__ == '__main__':
     log.info(f"Checking: {args.article_id} v{args.version_no}")
 
     # Define preservation object
-    p = Preserve(args.article_id, args.version_no,
-                 config_dict=config_dict, log=log)
+    try:
+        p = Preserve(args.article_id, args.version_no,
+                     config_dict=config_dict, log=log)
+    except SystemExit:
+        pass
 
     # Step 1: Save Figshare metadata
     p.save_metadata()

--- a/ldcoolp/scripts/preserve_checks
+++ b/ldcoolp/scripts/preserve_checks
@@ -33,7 +33,7 @@ if __name__ == '__main__':
                         help='path to configuration file')
     parser.add_argument('--article-id', required=True, type=int,
                         help='Figshare article ID')
-    parser.add_argument('--version-no', required=True, default=1, type=int,
+    parser.add_argument('--version-no', default=1, type=int,
                         help='Figshare article ID version no. Default: 1')
     parser.add_argument('--metadata-only', action='store_true',
                         help='Perform checks without checking files (this is for large datasets)')

--- a/ldcoolp/scripts/preserve_checks
+++ b/ldcoolp/scripts/preserve_checks
@@ -85,9 +85,12 @@ if __name__ == '__main__':
 
     log.info(f"Checking: {args.article_id} v{args.version_no}")
 
-    p = Preserve(args.article_id, args.version_no, config_dict=config_dict,
-                 log=log)
-    pprint(p.article_metadata)
+    # Define preservation object
+    p = Preserve(args.article_id, args.version_no,
+                 config_dict=config_dict, log=log)
+
+    # Step 1: Save Figshare metadata
+    p.save_metadata()
 
     log.info(f"Completed: {args.article_id} ...")
 

--- a/ldcoolp/scripts/preserve_checks
+++ b/ldcoolp/scripts/preserve_checks
@@ -108,7 +108,10 @@ if __name__ == '__main__':
         # Step 4: Create symbolic links
         p.make_symbolic_links(checksum_df)
 
-    # Step 6: Delete hidden files
+    # Step 6: Delete old README.txt files
+    p.delete_old_readme_files()
+
+    # Step 7: Delete hidden files
     p.delete_hidden_files()
 
     log.info(f"Completed: {args.article_id} ...")

--- a/ldcoolp/scripts/preserve_checks
+++ b/ldcoolp/scripts/preserve_checks
@@ -108,6 +108,9 @@ if __name__ == '__main__':
         # Step 4: Create symbolic links
         p.make_symbolic_links(checksum_df)
 
+    # Step 6: Delete hidden files
+    p.delete_hidden_files()
+
     log.info(f"Completed: {args.article_id} ...")
 
     # Change permission to mode=666 (rw for all)

--- a/ldcoolp/scripts/preserve_checks
+++ b/ldcoolp/scripts/preserve_checks
@@ -7,10 +7,13 @@ import argparse
 import configparser
 
 from datetime import date
-from pprint import pprint
 
+# LD-Cool-P specific
 from ldcoolp.preserve import Preserve
 from redata.commons import logger
+
+# Config loader
+from ldcoolp.config import dict_load
 
 # Version and branch info
 from ldcoolp import __version__, CODE_NAME
@@ -18,9 +21,6 @@ from redata.commons.git_info import GitInfo
 from ldcoolp import __file__ as library_path
 
 today = date.today()
-
-# Config loader
-from ldcoolp.config import dict_load
 
 library_root_path = dirname(dirname(library_path))  # Retrieve parent directory to ldcoolp
 
@@ -45,7 +45,9 @@ if __name__ == '__main__':
     gi = GitInfo(library_root_path)
 
     banner_message = f"""
-    This is the command-line tool that perform preservation checks
+    This is the command-line tool that perform preservation checks for curated
+    datasets. It only performs this after the dataset has been moved to the
+    published folder
 
     {CODE_NAME} branch: {gi.branch}
     {CODE_NAME} version: {__version__}

--- a/ldcoolp/scripts/preserve_checks
+++ b/ldcoolp/scripts/preserve_checks
@@ -36,7 +36,7 @@ if __name__ == '__main__':
     parser.add_argument('--version-no', required=True, default=1, type=int,
                         help='Figshare article ID version no. Default: 1')
     parser.add_argument('--metadata-only', action='store_true',
-                        help='Do not retrieve data, only metadata')
+                        help='Perform checks without checking files (this is for large datasets)')
     args = parser.parse_args()
 
     if not exists(args.config):
@@ -95,11 +95,12 @@ if __name__ == '__main__':
     p.save_metadata()
 
     # Step 2: Perform checksum verification on files
-    checksum_df = p.check_files(save_files=True)
+    if not args.metadata_only:
+        checksum_df = p.check_files(save_files=True)
 
-    for handler in log.handlers:
-        log_file = logger.get_log_file(handler)
-    logger.pandas_write_buffer(checksum_df, log_file)
+        for handler in log.handlers:
+            log_file = logger.get_log_file(handler)
+        logger.pandas_write_buffer(checksum_df, log_file)
 
     log.info(f"Completed: {args.article_id} ...")
 

--- a/ldcoolp/scripts/preserve_checks
+++ b/ldcoolp/scripts/preserve_checks
@@ -93,7 +93,7 @@ if __name__ == '__main__':
     p.save_metadata()
 
     # Step 2: Perform checksum verification on files
-    checksum_df = p.check_files()
+    checksum_df = p.check_files(save_files=True)
 
     for handler in log.handlers:
         log_file = logger.get_log_file(handler)

--- a/ldcoolp/scripts/preserve_checks
+++ b/ldcoolp/scripts/preserve_checks
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+
+from os.path import dirname, exists, join
+from os import mkdir
+
+import argparse
+import configparser
+
+from datetime import date
+from pprint import pprint
+
+from ldcoolp.preserve import Preserve
+from redata.commons import logger
+
+# Version and branch info
+from ldcoolp import __version__, CODE_NAME
+from redata.commons.git_info import GitInfo
+from ldcoolp import __file__ as library_path
+
+today = date.today()
+
+# Config loader
+from ldcoolp.config import dict_load
+
+library_root_path = dirname(dirname(library_path))  # Retrieve parent directory to ldcoolp
+
+
+if __name__ == '__main__':
+    # Parse command-line arguments
+    parser = argparse.ArgumentParser(
+        description='Command-line driver for LD-Cool-P preservation checks.')
+    parser.add_argument('--config', required=True,
+                        help='path to configuration file')
+    parser.add_argument('--article-id', required=True, type=int,
+                        help='Figshare article ID')
+    parser.add_argument('--version-no', required=True, default=1, type=int,
+                        help='Figshare article ID version no. Default: 1')
+    parser.add_argument('--metadata-only', action='store_true',
+                        help='Do not retrieve data, only metadata')
+    args = parser.parse_args()
+
+    if not exists(args.config):
+        raise FileNotFoundError(f"WARNING!!! Config file not found: {args.config}")
+
+    gi = GitInfo(library_root_path)
+
+    banner_message = f"""
+    This is the command-line tool that perform preservation checks
+
+    {CODE_NAME} branch: {gi.branch}
+    {CODE_NAME} version: {__version__}
+    {CODE_NAME} commit hash: {gi.short_commit}
+    Created by Chun Ly
+    Issues? Submit a GitHub ticket: https://github.com/UAL-RE/LD-Cool-P/issues/new
+    """
+    print(banner_message)
+
+    # Load configuration
+    try:
+        config_dict = dict_load(args.config)
+    except configparser.ParsingError:
+        exit()
+
+    curation_dict = config_dict['curation']
+
+    # Define logfile
+    root_directory_main = curation_dict[curation_dict['log_parent_dir']]
+
+    log_dir = join(root_directory_main, curation_dict['log_dir'])
+    if not exists(log_dir):
+        mkdir(log_dir)
+    logfile_prefix = 'preserve_checks'
+    log = logger.log_setup(log_dir, logfile_prefix)
+
+    lc = logger.LogCommons(log, logfile_prefix, gi,
+                           code_name=CODE_NAME, version=__version__)
+
+    lc.script_start()
+
+    # Retrieve username, hostname, IP
+    lc.script_sys_info()
+
+    # Configuration information
+    log.info(f"Config file: {args.config}")
+
+    log.info(f"Checking: {args.article_id} v{args.version_no}")
+
+    p = Preserve(args.article_id, args.version_no, config_dict=config_dict,
+                 log=log)
+    pprint(p.article_metadata)
+
+    log.info(f"Completed: {args.article_id} ...")
+
+    # Change permission to mode=666 (rw for all)
+    lc.log_permission()
+
+    lc.script_end()


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->

<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
<!-- A description of how this PR addresses the feature/enhancement. -->
This is WIP. Do not merge!
This is a new feature to support preparation for preservation checks.

<!-- Add any linked issue(s) -->
Closes #235


**ToDo List**

@astrochun:
As of 07/26/2021, here is the current status of this PR:
While most methods have been tested **at a minimum level** for the preservation check workflow, it is still not fully tested/explored. The methods of `Preserve` that have been tested include: `get_metadata`, `save_metadata`, `check_files`, `make_symbolic_links`, `delete_old_readme_files`, `delete_hidden_files`, `delete_files` (used by `delete_hidden_files`).

I have not tested:
- [ ] The `Preserve.update_files` method
- [ ] I have not done full end-to-end testing with instances where there is (1) no issue (i.e., curation version matches published version), (2) cases where the are differences between curation version and published version (we were not immediately aware of such a version for testing).
- [ ] I have not also tested this against dataset that does not have data (e.g., NPN datasets). Presumeably the `--metadata_only` option should work for this purpose.

In addition, we should have the script run as a "dry run" by default and to have a `--update` option. This will ensure that files are not replaced and to not download metadata. This would be a keyword input option that would need to be available to all method, probably through a (`self`) instance variable in `Preserve`.

**Test plan**
<!-- Explain how you tested this feature so that others can replicate it. -->
<!-- Example: The exact commands you ran and their output, screenshots. -->

**Update Changelog**
<!-- Be brief, use imperative mood or simple noun phrases and add linked issues -->
<!-- Examples: Improve verbosity of log messages #103 | GitHub actions for CI #105 -->

- [ ] [CHANGELOG.md](../blob/feature/235_preserve_prep/CHANGELOG.md) <!-- update changelog here -->


*Resources*
<!-- Links to blog posts, StackOverflow, libraries or add-ons used to solve this problem. -->


*Screenshots or additional context*
<!-- Add any other context about the problem here and/or screenshots to help explain the problem. -->
