### PR TITLE
Feature: Ensure graceful exit when deposit to be curated gets deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 # Changelog
 
-## [UNRELEASED](https://github.com/UAL-RE/LD-Cool-P/tree/HEAD) (YYYY-MM-DD)
+## [v1.1.5](https://github.com/UAL-RE/LD-Cool-P/tree/v1.1.5) (2021-07-19)
+
+**Implemented enhancements:**
+ - Feature: Ensure graceful exit when deposit to be curated gets deleted
+   [#239](https://github.com/UAL-RE/LD-Cool-P/pull/239)
 
 **Fixed bugs:**
  - get_user_details script does not write CSV for --simple case
    [#233](https://github.com/UAL-RE/LD-Cool-P/issues/233)
+
+**Closed issues:**
+ - Feature: Ensure graceful exit when deposit to be curated gets deleted
+   [#238](https://github.com/UAL-RE/LD-Cool-P/issues/238)
 
 **Merged pull requests:**
  - get_user_details script does not write CSV for --simple case

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You can confirm installation via `conda list`
 (curation) $ conda list ldcoolp
 ```
 
-You should see that the version is `1.1.4`.
+You should see that the version is `1.1.5`.
 
 ### Configuration Settings
 

--- a/ldcoolp/__init__.py
+++ b/ldcoolp/__init__.py
@@ -1,6 +1,6 @@
 from os import path
 
-__version__ = "1.1.4"
+__version__ = "1.1.5"
 
 CODE_NAME = "LD-Cool-P"
 

--- a/ldcoolp/curation/main.py
+++ b/ldcoolp/curation/main.py
@@ -72,6 +72,15 @@ class PrerequisiteWorkflow:
 
         self.metadata_only = metadata_only
 
+        # Check if deposit is not deleted by user
+        if self.dn.curation_dict['status'] == 'closed':
+            self.log.warning(
+                "This deposit was archived for one of many reasons!")
+            self.log.info(f"resolution_comment metadata info: "
+                          f"'{self.dn.curation_dict['resolution_comment']}'")
+            self.log.warning("Stopping data curation for this deposit")
+            raise SystemError
+
         # Check if dataset has been retrieved
         try:
             source_stage = self.mc.get_source_stage(self.dn.folderName, verbose=False)
@@ -152,9 +161,12 @@ def workflow(article_id, browser=True, log=None,
     if isinstance(log, type(None)):
         log = log_stdout()
 
-    pw = PrerequisiteWorkflow(article_id, log=log,
-                              config_dict=config_dict,
-                              metadata_only=metadata_only)
+    try:
+        pw = PrerequisiteWorkflow(article_id, log=log,
+                                  config_dict=config_dict,
+                                  metadata_only=metadata_only)
+    except SystemError:
+        return
 
     # Perform prerequisite workflow if dataset is entirely new
     if pw.new_set:

--- a/ldcoolp/curation/main.py
+++ b/ldcoolp/curation/main.py
@@ -72,7 +72,7 @@ class PrerequisiteWorkflow:
 
         self.metadata_only = metadata_only
 
-        # Check if deposit is not deleted by user
+        # Check if deposit is not archived (e.g., deleted by user, us, etc)
         if self.dn.curation_dict['status'] == 'closed':
             self.log.warning(
                 "This deposit was archived for one of many reasons!")

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fr:
 
 setup(
     name='ldcoolp',
-    version='1.1.4',
+    version='1.1.5',
     packages=['ldcoolp'],
     url='https://github.com/UAL-RE/LD-Cool-P',
     license='MIT License',


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->

<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
<!-- A description of how this PR addresses the feature/enhancement. -->
This easily fixes the 404 error that occurs when attempting to retrieve a dataset that was deleted for various reasons.
It uses the `status` metadata and also provides the message associated with `resolution_comment` metadata.

<!-- Add any linked issue(s) -->
Closes #238


**ToDo List**

**Test plan**
<!-- Explain how you tested this feature so that others can replicate it. -->
<!-- Example: The exact commands you ran and their output, screenshots. -->

 [x] Tested locally with a deposit that was deleted by user. Graceful exit

**Update Changelog**
<!-- Be brief, use imperative mood or simple noun phrases and add linked issues -->
<!-- Examples: Improve verbosity of log messages #103 | GitHub actions for CI #105 -->

- [x] README.md, [changelog](../../README.md#changelog) <!-- update changelog here -->

- [x] Bump version

*Resources*
<!-- Links to blog posts, StackOverflow, libraries or add-ons used to solve this problem. -->


*Screenshots or additional context*
<!-- Add any other context about the problem here and/or screenshots to help explain the problem. -->
