### PR TITLE
Fix: Update handling of : in citation generation (Issue #264)

### DIFF
--- a/ldcoolp/curation/api/qualtrics.py
+++ b/ldcoolp/curation/api/qualtrics.py
@@ -477,8 +477,8 @@ class Qualtrics:
         single_str_citation = df_curation['item']['citation']
 
         # handle period in author list.  Assume no period in dataset title
-        str_list = list([single_str_citation.split('):')[0] + '). '])
-        str_list += [str_row + '.' for str_row in single_str_citation.split('):')[1].split('. ')]
+        str_list = list([single_str_citation.split(').')[0] + '). '])
+        str_list += [str_row + '.' for str_row in single_str_citation.split(').')[1].split('. ')]
 
         citation_list = [content for content in str_list[0:-2]]
         citation_list.append(f"{str_list[-2]} {str_list[-1]}")


### PR DESCRIPTION
Figshare changed a `:` to a `.` as a terminator for the citation list. This  broke the code.

<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->
<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
Detects the author list termination by the string `).` instead of `):`

<!-- Add any linked issue(s) -->
Fixes #264 

*Testing (if applicable)*
Tested and working for the failing case.