### PR TITLE
Fix: Remove permission for others

### DIFF
--- a/ldcoolp/admin/move.py
+++ b/ldcoolp/admin/move.py
@@ -99,7 +99,7 @@ class MoveClass:
                 self.log.info(f"Path does not exist! {dest_path}")
                 self.log.info("Creating...")
                 makedirs(dest_path)
-                chmod(dest_path, 0o777)
+                chmod(dest_path, 0o770)
             shutil.move(source_path, dest_path)
 
             # Remove source_path parent folder if empty

--- a/ldcoolp/admin/permissions.py
+++ b/ldcoolp/admin/permissions.py
@@ -8,14 +8,14 @@ from os.path import join, isdir, isfile
 from os import chmod, walk
 
 
-def curation(path, mode=0o777):
+def curation(path, mode=0o770):
     """
     Purpose:
       Set permissions for all folders and files under the
       parent location of [path]
 
     :param path: Parent location path
-    :param mode: Mode. Default is rwx with '0o777'
+    :param mode: Mode. Default is rwx with '0o770'
     """
 
     if isdir(path) or isfile(path):

--- a/ldcoolp/admin/permissions.py
+++ b/ldcoolp/admin/permissions.py
@@ -8,22 +8,26 @@ from os.path import join, isdir, isfile
 from os import chmod, walk
 
 
-def curation(path, mode=0o770):
+def curation(path, folder_mode=0o2770, file_mode=0o2660):
     """
     Purpose:
       Set permissions for all folders and files under the
       parent location of [path]
 
     :param path: Parent location path
-    :param mode: Mode. Default is rwx with '0o770'
+    :param folder_mode: Mode for folders. Default is rwx with '0o770'
+    :param file_mode: Mode for files. Default is rw- with '660'
     """
 
-    if isdir(path) or isfile(path):
-        chmod(path, mode)
+    if isdir(path):
+        chmod(path, folder_mode)
+
+    if isfile(path):
+        chmod(path, file_mode)
 
     for dir_path, dir_names, files in walk(path):
         for dir_name in dir_names:
-            chmod(join(dir_path, dir_name), mode)
+            chmod(join(dir_path, dir_name), folder_mode)
 
         for file in files:
-            chmod(join(dir_path, file), mode)
+            chmod(join(dir_path, file), file_mode)

--- a/ldcoolp/curation/inspection/readme/__init__.py
+++ b/ldcoolp/curation/inspection/readme/__init__.py
@@ -1,5 +1,5 @@
 from os.path import exists, join, dirname, basename, getctime
-from os import walk, stat, symlink
+from os import walk, stat, symlink, chmod
 from datetime import datetime
 import shutil
 from glob import glob
@@ -277,7 +277,9 @@ class ReadmeClass:
 
             self.log.info(f"Source file name: {src_file}")
             shutil.copy(src_file, dest_file)
+            chmod(dest_file, 0o2660)
             shutil.copy(funders_macro_file_src, funders_macro_file_dest)
+            chmod(funders_macro_file_dest, 0o2660)
         else:
             self.log.info(f"{dest_file} exists. Not overwriting template!")
 

--- a/ldcoolp/curation/main.py
+++ b/ldcoolp/curation/main.py
@@ -111,7 +111,7 @@ class PrerequisiteWorkflow:
             if not exists(full_data_path):
                 self.log.info(f"Creating folder : {full_data_path}")
                 makedirs(full_data_path)
-                chmod(full_data_path, 0o777)
+                chmod(full_data_path, 0o770)
 
     def write_curation_metadata(self):
         """Write metadata from Figshare curation response"""

--- a/ldcoolp/curation/main.py
+++ b/ldcoolp/curation/main.py
@@ -111,10 +111,9 @@ class PrerequisiteWorkflow:
             full_data_path = join(self.root_directory, sub_dir)
             if not exists(full_data_path):
                 self.log.info(f"Creating folder : {full_data_path}")
-                makedirs(full_data_path)
+                makedirs(full_data_path, mode=0o2770, exist_ok=True)
                 Path(full_data_path).parent.chmod(0o2770)
                 Path(full_data_path).parent.parent.chmod(0o2770)
-                chmod(full_data_path, 0o2770)
 
 
     def write_curation_metadata(self):

--- a/ldcoolp/curation/main.py
+++ b/ldcoolp/curation/main.py
@@ -1,5 +1,6 @@
 from os.path import join, exists
 from os import makedirs, chmod
+from pathlib import Path
 
 # Logging
 from redata.commons.logger import log_stdout
@@ -111,7 +112,10 @@ class PrerequisiteWorkflow:
             if not exists(full_data_path):
                 self.log.info(f"Creating folder : {full_data_path}")
                 makedirs(full_data_path)
-                chmod(full_data_path, 0o770)
+                Path(full_data_path).parent.chmod(0o2770)
+                Path(full_data_path).parent.parent.chmod(0o2770)
+                chmod(full_data_path, 0o2770)
+
 
     def write_curation_metadata(self):
         """Write metadata from Figshare curation response"""

--- a/ldcoolp/curation/metadata.py
+++ b/ldcoolp/curation/metadata.py
@@ -1,3 +1,4 @@
+from os import chmod
 from typing import Union
 
 import os
@@ -53,6 +54,7 @@ def save_metadata(json_response: Union[list, dict],
         if overwrite:
             log.info("Overwriting!")
             write_json(json_out_file, json_response, log)
+    chmod(json_out_file, 0o2660)
 
     # Write CSV file
     if save_csv:
@@ -66,6 +68,7 @@ def save_metadata(json_response: Union[list, dict],
             if overwrite:
                 log.info("Overwriting!")
                 df.to_csv(csv_out_file, index=False)
+        chmod(csv_out_file, 0o2660)
 
     log.debug("finished.")
 

--- a/ldcoolp/curation/reports.py
+++ b/ldcoolp/curation/reports.py
@@ -32,7 +32,7 @@ def review_report(depositor_name='', curation_dict=config_default_dict['curation
     out_path = join(staging_directory, depositor_name, folder_ual_rdm)
     if not exists(out_path):
         log.info(f"Creating folder : {out_path}")
-        makedirs(out_path, mode=0o770, exist_ok=True)
+        makedirs(out_path, mode=0o2770, exist_ok=True)
     else:
         log.warn(f"!!!! Folder exists, not creating : {out_path}")
 

--- a/ldcoolp/curation/reports.py
+++ b/ldcoolp/curation/reports.py
@@ -32,7 +32,7 @@ def review_report(depositor_name='', curation_dict=config_default_dict['curation
     out_path = join(staging_directory, depositor_name, folder_ual_rdm)
     if not exists(out_path):
         log.info(f"Creating folder : {out_path}")
-        makedirs(out_path, mode=0o777, exist_ok=True)
+        makedirs(out_path, mode=0o770, exist_ok=True)
     else:
         log.warn(f"!!!! Folder exists, not creating : {out_path}")
 

--- a/ldcoolp/curation/retrieve.py
+++ b/ldcoolp/curation/retrieve.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 from os.path import exists
-
+from os import chmod
 import requests
 from requests import HTTPError
 
@@ -126,6 +126,7 @@ def download_files(article_id, fs, root_directory=None, data_directory=None,
                             checksum_flag = check_md5(filename,
                                                       file_dict['supplied_md5'])
                             if checksum_flag:
+                                chmod(filename, 0o2440)
                                 break
                         else:
                             log.info("Not performing checksum on linked-only record")
@@ -138,5 +139,4 @@ def download_files(article_id, fs, root_directory=None, data_directory=None,
                 log.info("File exists! Not overwriting!")
 
     # Change permissions on folders and files
-    # permissions.curation(dir_path)
-    permissions.curation(dir_path, mode=0o555)  # read and execute only
+    permissions.curation(dir_path, folder_mode=0o2550, file_mode=0o2440)  # read and execute only


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->
<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
<!-- A description of how this PR resolved the specified bug-->
This PR removes permission for "others" when creating or moving files and folders from one curation level to another.
 
<!-- Add any linked issue(s) -->
Fixes #283 

*Testing (if applicable)*
<!-- Explain how you tested this bug fix so that others can replicate it. -->
<!-- Example: The exact commands you ran and their output. -->
See "Steps To Reproduce" in #283 